### PR TITLE
Make `npm run build` sh compatible.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc",
-    "postbuild": "cp build/src/{client,soap-mapper,typesuite}.{d.ts,js} .; cp -R build/src/netsuite_webservices/* .; cp -R build/src/{xmlsoap,netsuite_webservices} .",
-    "clean": "rm -rf build/; rm *.{d.ts,js}; rm -rf {xmlsoap,netsuite_webservices,2019_2}",
+    "postbuild": "script/postbuild.sh",
+    "clean": "script/clean.sh",
     "deepClean": "npm run clean; rm -rf node_modules",
     "test": "jest test --testMatch '**/*.test.ts'"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git+https://github.com/StediInc/netsuite-adapters.git"
   },
   "scripts": {
-    "prepare": "npm run build",
+    "postinstall": "npm run build",
     "build": "tsc",
     "postbuild": "script/postbuild.sh",
     "clean": "script/clean.sh",

--- a/package.json
+++ b/package.json
@@ -7,21 +7,14 @@
     "NetSuite",
     "SuiteTalk"
   ],
-  "author": "David Farber <david+github@stedi.com>",
+  "author": "Stedi Engineering <engineering@stedi.com>",
   "homepage": "https://github.com/StediInc/TypeSuite#README.md",
   "license": "MIT",
   "main": "typesuite.js",
   "typings": "typesuite.d.ts",
-  "files": [
-    "*.d.ts",
-    "*.js",
-    "2019_2/**/*",
-    "netsuite_webservices/**/*",
-    "xmlsoap/**/*"
-  ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/StediInc/netsuite-adapters.git"
+    "url": "git+https://github.com/StediInc/TypeSuite.git"
   },
   "scripts": {
     "postinstall": "npm run build",

--- a/script/clean.sh
+++ b/script/clean.sh
@@ -1,0 +1,6 @@
+rm *.d.ts
+rm *.js
+rm -rf build
+rm -rf 2019_2
+rm -rf netsuite_webservices
+rm -rf xmlsoap

--- a/script/postbuild.sh
+++ b/script/postbuild.sh
@@ -1,0 +1,9 @@
+cp build/src/client.d.ts .
+cp build/src/client.js .
+cp build/src/soap-mapper.d.ts .
+cp build/src/soap-mapper.js .
+cp build/src/typesuite.d.ts .
+cp build/src/typesuite.js .
+cp -R build/src/netsuite_webservices/* .
+cp -R build/src/xmlsoap .
+cp -R build/src/netsuite_webservices .


### PR DESCRIPTION
  - Remove brace expansion, which is a bash feature

CI doesn't use the bash shell for some reason.  Some old hippie at AWS is trying to re-live the '60s.