### PR TITLE
refactor: reject promises on SOAP Faults

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -85,20 +85,6 @@ import {
   UpsertRequest,
   UpsertResponse,
 } from "./netsuite_webservices/2019_2/platform_messages";
-import {
-  AsyncFault,
-  ExceededConcurrentRequestLimitFault,
-  ExceededRecordCountFault,
-  ExceededRequestLimitFault,
-  ExceededRequestSizeFault,
-  ExceededUsageLimitFault,
-  InsufficientPermissionFault,
-  InvalidAccountFault,
-  InvalidCredentialsFault,
-  InvalidSessionFault,
-  InvalidVersionFault,
-  UnexpectedErrorFault,
-} from "./netsuite_webservices/2019_2/platform_faults";
 import { Configuration } from "./types";
 import { sendSoapRequest } from "./soap";
 
@@ -108,447 +94,137 @@ export class TypeSuiteClient {
     this.config = config;
   }
 
-  add(
-    request: AddRequest
-  ): Promise<
-    | AddResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  add(request: AddRequest): Promise<AddResponse> {
     return sendSoapRequest(this.config, request, "add");
   }
 
-  addList(
-    request: AddListRequest
-  ): Promise<
-    | AddListResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  addList(request: AddListRequest): Promise<AddListResponse> {
     return sendSoapRequest(this.config, request, "addList");
   }
 
-  asyncAddList(
-    request: AsyncAddListRequest
-  ): Promise<
-    | AsyncStatusResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  asyncAddList(request: AsyncAddListRequest): Promise<AsyncStatusResponse> {
     return sendSoapRequest(this.config, request, "asyncAddList");
   }
 
   asyncDeleteList(
     request: AsyncDeleteListRequest
-  ): Promise<
-    | AsyncStatusResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<AsyncStatusResponse> {
     return sendSoapRequest(this.config, request, "asyncDeleteList");
   }
 
-  asyncGetList(
-    request: AsyncGetListRequest
-  ): Promise<
-    | AsyncStatusResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  asyncGetList(request: AsyncGetListRequest): Promise<AsyncStatusResponse> {
     return sendSoapRequest(this.config, request, "asyncGetList");
   }
 
   asyncInitializeList(
     request: AsyncInitializeListRequest
-  ): Promise<
-    | AsyncStatusResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<AsyncStatusResponse> {
     return sendSoapRequest(this.config, request, "asyncInitializeList");
   }
 
-  asyncSearch(
-    request: AsyncSearchRequest
-  ): Promise<
-    | AsyncStatusResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  asyncSearch(request: AsyncSearchRequest): Promise<AsyncStatusResponse> {
     return sendSoapRequest(this.config, request, "asyncSearch");
   }
 
   asyncUpdateList(
     request: AsyncUpdateListRequest
-  ): Promise<
-    | AsyncStatusResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<AsyncStatusResponse> {
     return sendSoapRequest(this.config, request, "asyncUpdateList");
   }
 
   asyncUpsertList(
     request: AsyncUpsertListRequest
-  ): Promise<
-    | AsyncStatusResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<AsyncStatusResponse> {
     return sendSoapRequest(this.config, request, "asyncUpsertList");
   }
 
-  attach(
-    request: AttachRequest
-  ): Promise<
-    | AttachResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  attach(request: AttachRequest): Promise<AttachResponse> {
     return sendSoapRequest(this.config, request, "attach");
   }
 
-  changeEmail(
-    request: ChangeEmailRequest
-  ): Promise<
-    | ChangeEmailResponse
-    | InsufficientPermissionFault
-    | InvalidAccountFault
-    | InvalidCredentialsFault
-    | InvalidSessionFault
-    | InvalidVersionFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  changeEmail(request: ChangeEmailRequest): Promise<ChangeEmailResponse> {
     return sendSoapRequest(this.config, request, "changeEmail");
   }
 
   changePassword(
     request: ChangePasswordRequest
-  ): Promise<
-    | ChangePasswordResponse
-    | InsufficientPermissionFault
-    | InvalidAccountFault
-    | InvalidCredentialsFault
-    | InvalidSessionFault
-    | InvalidVersionFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<ChangePasswordResponse> {
     return sendSoapRequest(this.config, request, "changePassword");
   }
 
   checkAsyncStatus(
     request: CheckAsyncStatusRequest
-  ): Promise<
-    | AsyncStatusResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-    | AsyncFault
-  > {
+  ): Promise<AsyncStatusResponse> {
     return sendSoapRequest(this.config, request, "checkAsyncStatus");
   }
 
-  delete(
-    request: DeleteRequest
-  ): Promise<
-    | DeleteResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  delete(request: DeleteRequest): Promise<DeleteResponse> {
     return sendSoapRequest(this.config, request, "delete");
   }
 
-  deleteList(
-    request: DeleteListRequest
-  ): Promise<
-    | DeleteListResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  deleteList(request: DeleteListRequest): Promise<DeleteListResponse> {
     return sendSoapRequest(this.config, request, "deleteList");
   }
 
-  detach(
-    request: DetachRequest
-  ): Promise<
-    | DetachResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  detach(request: DetachRequest): Promise<DetachResponse> {
     return sendSoapRequest(this.config, request, "detach");
   }
 
-  get(
-    request: GetRequest
-  ): Promise<
-    | GetResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  get(request: GetRequest): Promise<GetResponse> {
     return sendSoapRequest(this.config, request, "get");
   }
 
-  getAll(
-    request: GetAllRequest
-  ): Promise<
-    | GetAllResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  getAll(request: GetAllRequest): Promise<GetAllResponse> {
     return sendSoapRequest(this.config, request, "getAll");
   }
 
   getAsyncResult(
     request: GetAsyncResultRequest
-  ): Promise<
-    | GetAsyncResultResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-    | AsyncFault
-  > {
+  ): Promise<GetAsyncResultResponse> {
     return sendSoapRequest(this.config, request, "getAsyncResult");
   }
 
   getBudgetExchangeRate(
     request: GetBudgetExchangeRateRequest
-  ): Promise<
-    | GetBudgetExchangeRateResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<GetBudgetExchangeRateResponse> {
     return sendSoapRequest(this.config, request, "getBudgetExchangeRate");
   }
 
   getCurrencyRate(
     request: GetCurrencyRateRequest
-  ): Promise<
-    | GetCurrencyRateResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<GetCurrencyRateResponse> {
     return sendSoapRequest(this.config, request, "getCurrencyRate");
   }
 
   getCustomizationId(
     request: GetCustomizationIdRequest
-  ): Promise<
-    | GetCustomizationIdResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<GetCustomizationIdResponse> {
     return sendSoapRequest(this.config, request, "getCustomizationId");
   }
 
   getDataCenterUrls(
     request: GetDataCenterUrlsRequest
-  ): Promise<
-    | GetDataCenterUrlsResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<GetDataCenterUrlsResponse> {
     return sendSoapRequest(this.config, request, "getDataCenterUrls");
   }
 
-  getDeleted(
-    request: GetDeletedRequest
-  ): Promise<
-    | GetDeletedResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  getDeleted(request: GetDeletedRequest): Promise<GetDeletedResponse> {
     return sendSoapRequest(this.config, request, "getDeleted");
   }
 
   getItemAvailability(
     request: GetItemAvailabilityRequest
-  ): Promise<
-    | GetItemAvailabilityResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<GetItemAvailabilityResponse> {
     return sendSoapRequest(this.config, request, "getItemAvailability");
   }
 
-  getList(
-    request: GetListRequest
-  ): Promise<
-    | GetListResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  getList(request: GetListRequest): Promise<GetListResponse> {
     return sendSoapRequest(this.config, request, "getList");
   }
 
   getPostingTransactionSummary(
     request: GetPostingTransactionSummaryRequest
-  ): Promise<
-    | GetPostingTransactionSummaryResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<GetPostingTransactionSummaryResponse> {
     return sendSoapRequest(
       this.config,
       request,
@@ -558,311 +234,89 @@ export class TypeSuiteClient {
 
   getSavedSearch(
     request: GetSavedSearchRequest
-  ): Promise<
-    | GetSavedSearchResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<GetSavedSearchResponse> {
     return sendSoapRequest(this.config, request, "getSavedSearch");
   }
 
   getSelectValue(
     request: GetSelectValueRequest
-  ): Promise<
-    | GetSelectValueResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<GetSelectValueResponse> {
     return sendSoapRequest(this.config, request, "getSelectValue");
   }
 
-  getServerTime(
-    request: GetServerTimeRequest
-  ): Promise<
-    | GetServerTimeResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | UnexpectedErrorFault
-  > {
+  getServerTime(request: GetServerTimeRequest): Promise<GetServerTimeResponse> {
     return sendSoapRequest(this.config, request, "getServerTime");
   }
 
-  initialize(
-    request: InitializeRequest
-  ): Promise<
-    | InitializeResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  initialize(request: InitializeRequest): Promise<InitializeResponse> {
     return sendSoapRequest(this.config, request, "initialize");
   }
 
   initializeList(
     request: InitializeListRequest
-  ): Promise<
-    | InitializeListResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<InitializeListResponse> {
     return sendSoapRequest(this.config, request, "initializeList");
   }
 
-  login(
-    request: LoginRequest
-  ): Promise<
-    | LoginResponse
-    | InsufficientPermissionFault
-    | InvalidAccountFault
-    | InvalidCredentialsFault
-    | InvalidSessionFault
-    | InvalidVersionFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  login(request: LoginRequest): Promise<LoginResponse> {
     return sendSoapRequest(this.config, request, "login");
   }
 
-  logout(
-    request: LogoutRequest
-  ): Promise<
-    | LogoutResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  logout(request: LogoutRequest): Promise<LogoutResponse> {
     return sendSoapRequest(this.config, request, "logout");
   }
 
-  mapSso(
-    request: MapSsoRequest
-  ): Promise<
-    | MapSsoResponse
-    | InsufficientPermissionFault
-    | InvalidAccountFault
-    | InvalidCredentialsFault
-    | InvalidSessionFault
-    | InvalidVersionFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  mapSso(request: MapSsoRequest): Promise<MapSsoResponse> {
     return sendSoapRequest(this.config, request, "mapSso");
   }
 
-  search(
-    request: SearchRequest
-  ): Promise<
-    | SearchResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  search(request: SearchRequest): Promise<SearchResponse> {
     return sendSoapRequest(this.config, request, "search");
   }
 
-  searchMore(
-    request: SearchMoreRequest
-  ): Promise<
-    | SearchMoreResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  searchMore(request: SearchMoreRequest): Promise<SearchMoreResponse> {
     return sendSoapRequest(this.config, request, "searchMore");
   }
 
   searchMoreWithId(
     request: SearchMoreWithIdRequest
-  ): Promise<
-    | SearchMoreWithIdResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<SearchMoreWithIdResponse> {
     return sendSoapRequest(this.config, request, "searchMoreWithId");
   }
 
-  searchNext(
-    request: SearchNextRequest
-  ): Promise<
-    | SearchNextResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  searchNext(request: SearchNextRequest): Promise<SearchNextResponse> {
     return sendSoapRequest(this.config, request, "searchNext");
   }
 
-  ssoLogin(
-    request: SsoLoginRequest
-  ): Promise<
-    | SsoLoginResponse
-    | InsufficientPermissionFault
-    | InvalidAccountFault
-    | InvalidCredentialsFault
-    | InvalidSessionFault
-    | InvalidVersionFault
-    | ExceededRequestLimitFault
-    | UnexpectedErrorFault
-  > {
+  ssoLogin(request: SsoLoginRequest): Promise<SsoLoginResponse> {
     return sendSoapRequest(this.config, request, "ssoLogin");
   }
 
-  update(
-    request: UpdateRequest
-  ): Promise<
-    | UpdateResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  update(request: UpdateRequest): Promise<UpdateResponse> {
     return sendSoapRequest(this.config, request, "update");
   }
 
   updateInviteeStatus(
     request: UpdateInviteeStatusRequest
-  ): Promise<
-    | UpdateInviteeStatusResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<UpdateInviteeStatusResponse> {
     return sendSoapRequest(this.config, request, "updateInviteeStatus");
   }
 
   updateInviteeStatusList(
     request: UpdateInviteeStatusListRequest
-  ): Promise<
-    | UpdateInviteeStatusListResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  ): Promise<UpdateInviteeStatusListResponse> {
     return sendSoapRequest(this.config, request, "updateInviteeStatusList");
   }
 
-  updateList(
-    request: UpdateListRequest
-  ): Promise<
-    | UpdateListResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  updateList(request: UpdateListRequest): Promise<UpdateListResponse> {
     return sendSoapRequest(this.config, request, "updateList");
   }
 
-  upsert(
-    request: UpsertRequest
-  ): Promise<
-    | UpsertResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  upsert(request: UpsertRequest): Promise<UpsertResponse> {
     return sendSoapRequest(this.config, request, "upsert");
   }
 
-  upsertList(
-    request: UpsertListRequest
-  ): Promise<
-    | UpsertListResponse
-    | InsufficientPermissionFault
-    | InvalidSessionFault
-    | InvalidCredentialsFault
-    | ExceededConcurrentRequestLimitFault
-    | ExceededRequestLimitFault
-    | ExceededUsageLimitFault
-    | ExceededRecordCountFault
-    | ExceededRequestSizeFault
-    | UnexpectedErrorFault
-  > {
+  upsertList(request: UpsertListRequest): Promise<UpsertListResponse> {
     return sendSoapRequest(this.config, request, "upsertList");
   }
 }

--- a/src/soap.ts
+++ b/src/soap.ts
@@ -49,7 +49,6 @@ export function serializeSoapRequest(
     header: new Header({ any: [{ name: headerElementKey, value: header }] }),
     body: new Body({ any: [{ name: bodyElementKey, value: body }] }),
   });
-
   const data = { "soap:Envelope": envelope };
   const context = new Jsonix.Context(ALL_MAPPINGS, JSONIX_CONTEXT_OPTIONS);
   const xmlString = context.createMarshaller().marshalString(data);

--- a/src/xmlsoap/envelope.ts
+++ b/src/xmlsoap/envelope.ts
@@ -13,7 +13,7 @@ export class Fault {
 
 export class Detail {
   otherAttributes?: string;
-  any?: string[];
+  any?: any[];
   constructor(props: Detail) {
     this.otherAttributes = props.otherAttributes;
     this.any = props.any;
@@ -24,7 +24,7 @@ export class Envelope {
   otherAttributes?: string;
   header?: Header;
   body: Body;
-  any?: string[];
+  any?: any[];
   constructor(props: Envelope) {
     this.otherAttributes = props.otherAttributes;
     this.header = props.header;

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -172,3 +172,28 @@ export function expectedSearchRequestXml(date: string): string {
     "</soap:Envelope>"
   );
 }
+
+export function soapFaultXml(): string {
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"' +
+    '                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"' +
+    '                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+    "    <soapenv:Body>" +
+    "        <soapenv:Fault>" +
+    "            <faultcode>soapenv:Server.userException</faultcode>" +
+    "            <faultstring>Invalid login attempt.</faultstring>" +
+    "            <detail>" +
+    "                <platformFaults:invalidCredentialsFault" +
+    '                        xmlns:platformFaults="urn:faults_2019_2.platform.webservices.netsuite.com">' +
+    "                    <platformFaults:code>USER_ERROR</platformFaults:code>" +
+    "                    <platformFaults:message>Invalid login attempt.</platformFaults:message>" +
+    "                </platformFaults:invalidCredentialsFault>" +
+    '                <ns1:hostname xmlns:ns1="http://xml.apache.org/axis/">partners030' +
+    "                </ns1:hostname>" +
+    "            </detail>" +
+    "        </soapenv:Fault>" +
+    "    </soapenv:Body>" +
+    "</soapenv:Envelope>"
+  );
+}

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -197,3 +197,43 @@ export function soapFaultXml(): string {
     "</soapenv:Envelope>"
   );
 }
+
+export function soapSuccessXml(): string {
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"\n' +
+    '                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"\n' +
+    '                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n' +
+    "    <soapenv:Header>\n" +
+    "        <platformMsgs:documentInfo\n" +
+    '                xmlns:platformMsgs="urn:messages_2019_2.platform.webservices.netsuite.com">\n' +
+    "            <platformMsgs:nsId>WEBSERVICES_TSTDRV1982068_101420206783052241624369917_9d3834</platformMsgs:nsId>\n" +
+    "        </platformMsgs:documentInfo>\n" +
+    "    </soapenv:Header>\n" +
+    "    <soapenv:Body>\n" +
+    '        <searchResponse xmlns="urn:messages_2019_2.platform.webservices.netsuite.com">\n' +
+    "            <platformCore:searchResult\n" +
+    '                    xmlns:platformCore="urn:core_2019_2.platform.webservices.netsuite.com">\n' +
+    '                <platformCore:status isSuccess="true"/>\n' +
+    "                <platformCore:totalRecords>1</platformCore:totalRecords>\n" +
+    "                <platformCore:pageSize>1000</platformCore:pageSize>\n" +
+    "                <platformCore:totalPages>1</platformCore:totalPages>\n" +
+    "                <platformCore:pageIndex>1</platformCore:pageIndex>\n" +
+    "                <platformCore:searchId>WEBSERVICES_TSTDRV1982068_101420206783052241624369917_9d3834</platformCore:searchId>\n" +
+    "                <platformCore:searchRowList>\n" +
+    '                    <platformCore:searchRow xsi:type="tranSales:TransactionSearchRow"\n' +
+    '                                            xmlns:tranSales="urn:sales_2019_2.transactions.webservices.netsuite.com">\n' +
+    "                        <tranSales:basic\n" +
+    '                                xmlns:platformCommon="urn:common_2019_2.platform.webservices.netsuite.com">\n' +
+    "                            <platformCommon:internalId>\n" +
+    '                                <platformCore:searchValue internalId="392562"/>\n' +
+    "                            </platformCommon:internalId>\n" +
+    "                        </tranSales:basic>\n" +
+    "                    </platformCore:searchRow>\n" +
+    "                </platformCore:searchRowList>\n" +
+    "            </platformCore:searchResult>\n" +
+    "        </searchResponse>\n" +
+    "    </soapenv:Body>\n" +
+    "</soapenv:Envelope>"
+  );
+}

--- a/test/soap.test.ts
+++ b/test/soap.test.ts
@@ -1,15 +1,27 @@
+/* eslint-disable jest/no-conditional-expect */
 import {
   LoginRequest,
   SearchRequest,
 } from "../src/netsuite_webservices/2019_2/platform_messages";
 import { TransactionSearchAdvanced } from "../src/netsuite_webservices/2019_2/transactions_sales";
-import { deserializeSoapResponse, serializeSoapRequest } from "../src/soap";
+import {
+  deserializeSoapResponse,
+  sendSoapRequest,
+  serializeSoapRequest,
+} from "../src/soap";
 import {
   expectedDeserializedLoginRequest,
   expectedLoginRequestXml,
   expectedSearchRequestXml,
+  soapFaultXml,
   tokenPassport,
 } from "./fixtures";
+import { TransactionSearchBasic } from "../src/netsuite_webservices/2019_2/platform_common";
+import { mocked } from "ts-jest/utils";
+import axios from "axios";
+import { Fault } from "../src/xmlsoap/envelope";
+
+jest.mock("axios");
 
 describe("serializing and deserializing requests", () => {
   it("works in both directions", () => {
@@ -58,5 +70,77 @@ describe("serializing and deserializing requests", () => {
     );
 
     expect(result).toEqual(expectedSearchRequestXml(aDate));
+  });
+});
+
+describe("Sending requests", () => {
+  it("rejects the promise when there is a fault", async () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    mocked(axios.post).mockRejectedValue({
+      config: {},
+      response: {
+        data: soapFaultXml(),
+        status: 500,
+        statusText: "Server Error",
+        headers: {},
+        config: {},
+      },
+      isAxiosError: false,
+      toJSON: () => "",
+    });
+
+    expect.assertions(3);
+    try {
+      await sendSoapRequest(
+        {
+          account: "fake",
+          apiVersion: "2019_2",
+          token: {
+            consumerKey: "wrong-value",
+            consumerSecret: "wrong-value",
+            tokenKey: "wrong-value",
+            tokenSecret: "wrong-value",
+          },
+        },
+        new SearchRequest({
+          searchRecord: new TransactionSearchAdvanced({
+            criteria: {
+              basic: new TransactionSearchBasic({
+                closed: false,
+              }),
+            },
+          }),
+        }),
+        "search"
+      );
+    } catch (error) {
+      const fault = (error as unknown) as Fault;
+      expect(fault.faultstring).toEqual("Invalid login attempt.");
+      expect(fault.faultcode).toEqual({
+        key: "{http://schemas.xmlsoap.org/soap/envelope/}Server.userException",
+        localPart: "Server.userException",
+        namespaceURI: "http://schemas.xmlsoap.org/soap/envelope/",
+        prefix: "soapenv",
+        string:
+          "{http://schemas.xmlsoap.org/soap/envelope/}soapenv:Server.userException",
+      });
+      expect(fault.detail?.any?.[0]).toEqual({
+        name: {
+          key:
+            "{urn:faults_2019_2.platform.webservices.netsuite.com}invalidCredentialsFault",
+          localPart: "invalidCredentialsFault",
+          namespaceURI: "urn:faults_2019_2.platform.webservices.netsuite.com",
+          prefix: "platformFaults",
+          string:
+            "{urn:faults_2019_2.platform.webservices.netsuite.com}platformFaults:invalidCredentialsFault",
+        },
+        value: {
+          TYPE_NAME:
+            "com_netsuite_webservices_platform_faults_2019_2.InvalidCredentialsFault",
+          code: "USER_ERROR",
+          message: "Invalid login attempt.",
+        },
+      });
+    }
   });
 });


### PR DESCRIPTION
This commit changes the client API to return a resolved promise on
success and a rejected promise on error.

Fixes #116