### PR TITLE
fix: set package.json to 0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stedi-oss/typesuite",
-  "version": "0.7.1",
+  "version": "0.0.0",
   "description": "TypeScript client for NetSuite SuiteTalk SOAP API",
   "keywords": [
     "TypeScript",


### PR DESCRIPTION
The version is managed by the tags and the package.json version is
meaningless.