### PR TITLE
fix(dependabot): increase amount of characters allowed in commit msg

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
       "@commitlint/config-conventional"
     ],
     "rules": {
-      "body-max-line-length": [1, "always", 144],
+      "body-max-line-length": [1, "always", 144]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
-    ]
+    ],
+    "rules": {
+      "body-max-line-length": [1, "always", 144],
+    }
   }
 }


### PR DESCRIPTION
Dependabot updates are failing due to this: https://github.com/Stedi/typesuite/pull/130/checks?check_run_id=1266108517