### PR TITLE
fix: add commit signing for semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,21 @@ jobs:
         run: npm ci
         env:
           GITHUB_TOKEN: ${{ secrets.ENG_GITHUB_TOKEN }}
+      - uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{secrets.STEDI_ENGINEERING_GPG_PRIVATE_KEY}}
+          passphrase: ${{secrets.STEDI_ENGINEERING_GPG_PASSPHRASE}}
+          git-user-signingkey: true
+          git-commit-gpgsign: true
+        id: import_gpg
+      - run: 'echo "email: ${{ steps.import_gpg.outputs.email }}"'
+        env: {}
       - name: Release
         env:
+          GIT_AUTHOR_NAME: ${{steps.import_gpg.outputs.name}}
+          GIT_COMMITTER_NAME: ${{steps.import_gpg.outputs.name}}
+          GIT_AUTHOR_EMAIL: ${{steps.import_gpg.outputs.email}}
+          GIT_COMMITTER_EMAIL: ${{steps.import_gpg.outputs.email}}
           GITHUB_TOKEN: ${{ secrets.ENG_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run release


### PR DESCRIPTION
** Background **

It seems that haven't been any updates to this repo since we enabled commit signature protection for all repos in the org. Because the commits performed via `semantic-release` weren't signed on the previous PR, the release workflow failed. 

** Change **

Configure commit signing for the release workflow.

